### PR TITLE
Bugfix - Meta Description Widget shows errors with less than 8 pages

### DIFF
--- a/Classes/Widgets/Provider/PagesWithoutDescriptionDataProvider.php
+++ b/Classes/Widgets/Provider/PagesWithoutDescriptionDataProvider.php
@@ -57,6 +57,7 @@ class PagesWithoutDescriptionDataProvider implements PageProviderInterface
 
             $iterator++;
 
+            // If the $row is false, no row is returned from database. All matched $items in array will be returned.
             if($row === false) {
                 return $items;
             }

--- a/Classes/Widgets/Provider/PagesWithoutDescriptionDataProvider.php
+++ b/Classes/Widgets/Provider/PagesWithoutDescriptionDataProvider.php
@@ -41,22 +41,32 @@ class PagesWithoutDescriptionDataProvider implements PageProviderInterface
         ];
 
         $items = [];
+        $counter = 0;
+        $iterator = 0;
 
-        $results = $queryBuilder
+        while ($counter < $this->limit) {
+            $row = $queryBuilder
             ->select('*')
             ->from('pages')
             ->where(...$constraints)
             ->orderBy('tstamp', 'DESC')
-            ->setMaxResults($this->limit)
+                ->setFirstResult($iterator)
+                ->setMaxResults(1)
             ->execute()
-            ->fetchAll();
+                ->fetch();
 
-        foreach($results as $row) {
+            $iterator++;
+
+            if($row === false) {
+                return $items;
+            }
+
             if (!$this->getBackendUser()->doesUserHaveAccess($row, Permission::PAGE_SHOW)) {
                 continue;
             }
 
             $items[] = $row;
+            $counter++;
         }
 
         return $items;

--- a/Classes/Widgets/Provider/PagesWithoutDescriptionDataProvider.php
+++ b/Classes/Widgets/Provider/PagesWithoutDescriptionDataProvider.php
@@ -41,29 +41,24 @@ class PagesWithoutDescriptionDataProvider implements PageProviderInterface
         ];
 
         $items = [];
-        $counter = 0;
-        $iterator = 0;
 
-        while ($counter < $this->limit) {
-            $row = $queryBuilder
-                ->select('*')
-                ->from('pages')
-                ->where(...$constraints)
-                ->orderBy('tstamp', 'DESC')
-                ->setFirstResult($iterator)
-                ->setMaxResults(1)
-                ->execute()
-                ->fetch();
+        $results = $queryBuilder
+            ->select('*')
+            ->from('pages')
+            ->where(...$constraints)
+            ->orderBy('tstamp', 'DESC')
+            ->setMaxResults($this->limit)
+            ->execute()
+            ->fetchAll();
 
-            $iterator++;
-
+        foreach($results as $row) {
             if (!$this->getBackendUser()->doesUserHaveAccess($row, Permission::PAGE_SHOW)) {
                 continue;
             }
 
             $items[] = $row;
-            $counter++;
         }
+
         return $items;
     }
 

--- a/Classes/Widgets/Provider/PagesWithoutDescriptionDataProvider.php
+++ b/Classes/Widgets/Provider/PagesWithoutDescriptionDataProvider.php
@@ -46,13 +46,13 @@ class PagesWithoutDescriptionDataProvider implements PageProviderInterface
 
         while ($counter < $this->limit) {
             $row = $queryBuilder
-            ->select('*')
-            ->from('pages')
-            ->where(...$constraints)
-            ->orderBy('tstamp', 'DESC')
+                ->select('*')
+                ->from('pages')
+                ->where(...$constraints)
+                ->orderBy('tstamp', 'DESC')
                 ->setFirstResult($iterator)
                 ->setMaxResults(1)
-            ->execute()
+                ->execute()
                 ->fetch();
 
             $iterator++;
@@ -69,7 +69,6 @@ class PagesWithoutDescriptionDataProvider implements PageProviderInterface
             $items[] = $row;
             $counter++;
         }
-
         return $items;
     }
 


### PR DESCRIPTION
This will fix Issue #19 and #20 
The while loop encountered into empty rows which where null.
Now only rows with content will be stored into the $items array.
I tested it in TYPO3 10.4.1