### PR TITLE
[TASK] Require 11.0.*@dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     }
   ],
   "require": {
-    "typo3/cms-core": "^10.4 || 10.4.*@dev",
-    "typo3/cms-dashboard": "^10.4 || 10.4.*@dev"
+    "typo3/cms-core": "^10.4 || 11.0.*@dev",
+    "typo3/cms-dashboard": "^10.4 || 11.0.*@dev"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,8 +8,8 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.1.0-dev',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.0 - 10.4.99',
-            'dashboard' => '10.4.0 - 10.4.99'
+            'typo3' => '10.4.0 - 11.0.99',
+            'dashboard' => '10.4.0 - 11.0.99'
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Tried to install the widget extension on current TYPO3 Master but require of widget extensions was not correct.

To test: run `composer require friendsoftypo3/widgets:"dev-feature/require-TYPO3.11.0dev"`