### PR TITLE
[FIX] Adds extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,10 @@
     "cgl-fix": [
       "php-cs-fixer fix -v --using-cache false"
     ]
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "widgets"
+    }
   }
 }


### PR DESCRIPTION
Resolves #27 

I added the extension-key into the composer.json as it is described in https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra

This will be mandatory in the next TYPO3 versions