### PR TITLE
[TASK] Set editor config of json files to use spaces as indenting 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,7 +23,8 @@ indent_size = 2
 
 # JSON-Files
 [*.json]
-indent_style = tab
+indent_style = space
+indent_size = 2
 
 # ReST-Files
 [*.rst]

--- a/Build/package.json
+++ b/Build/package.json
@@ -1,30 +1,30 @@
 {
-	"name": "friendsoftypo3_widgets",
-	"description": "Dashboard Widgets for TYPO3",
-	"repository": "https://github.com/FriendsOfTYPO3/widgets.git",
-	"readme": "../README.md",
-	"author": "Koen Wouters",
-	"main": "Gruntfile.js",
-	"version": "1.0.0-dev",
-	"license": "GPL-2.0+",
-	"engines": {
-		"node": ">=12.0.0 <13.0.0",
-		"yarn": "^1.10.0"
-	},
-	"devDependencies": {
-		"autoprefixer": "^9.5.1",
-		"grunt": "^1.3.0",
-		"grunt-contrib-cssmin": "^3.0.0",
-		"grunt-contrib-watch": "^1.1.0",
-		"grunt-postcss": "^0.9.0",
-		"grunt-sass": "^3.0.2",
-		"grunt-sass-globbing": "^1.5.1",
-		"grunt-sass-lint": "^0.2.4",
-		"jit-grunt": "^0.10.0",
-		"node-sass": "^4.12.0"
-	},
-	"scripts": {
-		"lint": "./node_modules/.bin/grunt lint",
-		"build": "./node_modules/.bin/grunt build"
-	}
+  "name": "friendsoftypo3_widgets",
+  "description": "Dashboard Widgets for TYPO3",
+  "repository": "https://github.com/FriendsOfTYPO3/widgets.git",
+  "readme": "../README.md",
+  "author": "Koen Wouters",
+  "main": "Gruntfile.js",
+  "version": "1.0.0-dev",
+  "license": "GPL-2.0+",
+  "engines": {
+    "node": ">=12.0.0 <13.0.0",
+    "yarn": "^1.10.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^9.5.1",
+    "grunt": "^1.3.0",
+    "grunt-contrib-cssmin": "^3.0.0",
+    "grunt-contrib-watch": "^1.1.0",
+    "grunt-postcss": "^0.9.0",
+    "grunt-sass": "^3.0.2",
+    "grunt-sass-globbing": "^1.5.1",
+    "grunt-sass-lint": "^0.2.4",
+    "jit-grunt": "^0.10.0",
+    "node-sass": "^4.12.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/.bin/grunt lint",
+    "build": "./node_modules/.bin/grunt build"
+  }
 }


### PR DESCRIPTION
Issue #34

Indenting of json files is now spaces instead of tabs.